### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -40,8 +40,8 @@ jobs:
         run: |-
           os=${{ matrix.os }}
           node=${{ matrix.node-version }}
-          echo "::set-output name=os::${os/-latest/}"
-          echo "::set-output name=node::node_${node//[.*]/}"
+          echo "os=${os/-latest/}" >> "$GITHUB_OUTPUT"
+          echo "node=node_${node//[.*]/}" >> "$GITHUB_OUTPUT"
         shell: bash
       - uses: codecov/codecov-action@v2
         with:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter